### PR TITLE
Changed access modifier to 'protected' for rootSuiteId in ScenarioReporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.6.1
+##### Changed access modifier to 'protected' for rootSuiteId in ScenarioReporter to allow inherit this reporter without unnecessary code duplication.
+
 ## 2.6.0
 ##### Released: 20 November 2016
 

--- a/src/main/java/com/epam/reportportal/cucumber/ScenarioReporter.java
+++ b/src/main/java/com/epam/reportportal/cucumber/ScenarioReporter.java
@@ -53,7 +53,7 @@ import gherkin.formatter.model.Step;
 public class ScenarioReporter extends AbstractReporter {
 	private static final String SEPARATOR = "-------------------------";
 
-	private String rootSuiteId;
+	protected String rootSuiteId;
 
 	public ScenarioReporter() {
 		super();


### PR DESCRIPTION
Changed access modifier to 'protected' for rootSuiteId in ScenarioReporter to allow inherit this reporter without unnecessary code duplication.
For now this field is private and you will experience troubles trying to override startRootItem() method with intention to customize test suites in multithreading environment.