### PR TITLE
issue_188 fixed, root item initialization moved before parent

### DIFF
--- a/src/main/java/com/epam/reportportal/cucumber/AbstractReporter.java
+++ b/src/main/java/com/epam/reportportal/cucumber/AbstractReporter.java
@@ -115,13 +115,12 @@ public abstract class AbstractReporter implements Formatter, Reporter {
 	 */
 	protected void beforeFeature(Feature feature) {
 		StartTestItemRQ rq = new StartTestItemRQ();
+		Maybe<String> root = getRootItemId();
 		rq.setDescription(Utils.buildStatementName(feature, null, AbstractReporter.COLON_INFIX, null));
 		rq.setName(currentFeatureUri);
 		rq.setTags(extractTags(feature.getTags()));
 		rq.setStartTime(Calendar.getInstance().getTime());
 		rq.setType(getFeatureTestItemType());
-
-		Maybe<String> root = getRootItemId();
 		if (null == root) {
 			currentFeatureId = RP.get().startTestItem(rq);
 		} else {


### PR DESCRIPTION
issue 188 fix. https://github.com/reportportal/reportportal/issues/188

Error Message: Start time of child ['Wed Jul 19 12:53:49 UTC 2017'] item should be same or later than start time ['Wed Jul 19 12:53:49 UTC 2017'] of the parent item/launch '596f565d2ab79c0007b48b46' Error Type: CHILD_START_TIME_EARLIER_THAN_PARENT

Issue caused by using memoize(Supplier<T> delegate) that retrieve instance during the first call to get(),
instance initialization moved before initialization of child item in report.