### PR TITLE
cover situation when there is no tests in whole execution

### DIFF
--- a/src/main/java/com/epam/reportportal/cucumber/ScenarioReporter.java
+++ b/src/main/java/com/epam/reportportal/cucumber/ScenarioReporter.java
@@ -25,6 +25,8 @@ import gherkin.formatter.model.Match;
 import gherkin.formatter.model.Result;
 import gherkin.formatter.model.Step;
 import io.reactivex.Maybe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import rp.com.google.common.base.Supplier;
 import rp.com.google.common.base.Suppliers;
 
@@ -51,6 +53,7 @@ import java.util.Calendar;
  */
 public class ScenarioReporter extends AbstractReporter {
 	private static final String SEPARATOR = "-------------------------";
+	private static final Logger LOGGER = LoggerFactory.getLogger(ScenarioReporter.class);
 
 	protected Supplier<Maybe<String>> rootSuiteId = Suppliers.memoize(new Supplier<Maybe<String>>() {
 		@Override
@@ -108,9 +111,12 @@ public class ScenarioReporter extends AbstractReporter {
 
 	@Override
 	protected void afterLaunch() {
+		if(currentFeatureUri == null){
+			LOGGER.debug("There is no scenarios in the launch");
+			return;
+		}
 		Utils.finishTestItem(RP.get(), rootSuiteId.get());
 		rootSuiteId = null;
-
 		super.afterLaunch();
 	}
 


### PR DESCRIPTION
Problem details:

1. Particular tags are specified in Cucumber options.
2. There is no Scenarios, which matched these tags
3. Execution starts and goes to com.epam.reportportal.cucumber.ScenarioReporter#afterLaunch where we perform `Utils.finishTestItem(RP.get(), rootSuiteId.get());`
4. Which means we start "Root User Story" item and immediately try to finish them
5. As result we have error:

> Error Message: Test item status is ambiguous. There is no status provided from request and there are no descendants to check statistics for test item id '5b581e9e8a7f71041c4e200c'
Error Type: AMBIGUOUS_TEST_ITEM_STATUS

For resolving this I just skip afterLaunch methods if `currentFeatureUri` value is not initialized (it can be only if no executed scenarios in run)